### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -7,6 +7,8 @@ jobs:
   assign:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Assign reviewer
         uses: actions/github-script@v7


### PR DESCRIPTION
Potential fix for [https://github.com/r3bo0tbx1/tor-guard-relay/security/code-scanning/8](https://github.com/r3bo0tbx1/tor-guard-relay/security/code-scanning/8)

In general, the fix is to add a `permissions` block that restricts the `GITHUB_TOKEN` to the least privileges required. For this job, the only capability needed is the ability to request reviewers on pull requests, which requires `pull-requests: write`. It does not need broad `contents: write` or other elevated scopes, so we should explicitly set a minimal set of permissions.

The best fix, without changing existing functionality, is to add a job-level `permissions` block under `jobs.assign`, specifying `pull-requests: write`. This keeps the scope local to this job, avoids affecting other workflows, and clearly documents the intent. Concretely, in `.github/workflows/assign.yml`, under `jobs:  assign:`, add:

```yaml
    permissions:
      pull-requests: write
```

at the same indentation level as `if:` and `runs-on:`. No new imports or external actions are required; GitHub Actions’ built-in permission system handles this.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
