### PR TITLE
🔧 build(deps): add automerge for patch/digest updates and reviewer coverage

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -54,7 +54,6 @@
     "enabled": true,
     "labels": ["security", "dependencies"],
     "assignees": ["r3bo0tbx1"],
-    "reviewers": ["r3bo0tbx1"],
     "schedule": ["at any time"]
   },
   "osvVulnerabilityAlerts": true,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,15 +6,12 @@
     ":disableDependencyDashboard",
     ":prHourlyLimit2"
   ],
-
   "labels": ["dependencies"],
-  "commitMessagePrefix": "build",
+  "commitMessagePrefix": "⬆️ build(deps):",
   "rebaseWhen": "behind-base-branch",
   "assignees": ["r3bo0tbx1"],
   "reviewers": ["r3bo0tbx1"],
-
   "enabledManagers": ["dockerfile", "github-actions"],
-
   "packageRules": [
     {
       "matchDatasources": ["docker"],
@@ -43,19 +40,25 @@
       "schedule": ["before 3am on monday"],
       "prPriority": 3,
       "automerge": false
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["patch", "digest"],
+      "groupName": "GitHub Actions (patch/digest)",
+      "labels": ["dependencies", "github-actions"],
+      "schedule": ["before 3am on monday"],
+      "automerge": true
     }
   ],
-
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security", "dependencies"],
     "assignees": ["r3bo0tbx1"],
+    "reviewers": ["r3bo0tbx1"],
     "schedule": ["at any time"]
   },
-
   "osvVulnerabilityAlerts": true,
   "timezone": "UTC",
   "prConcurrentLimit": 5,
-
   "description": "Renovate tracks Docker base images and GitHub Actions. Alpine packages (tor and tini) are not pinned and update automatically via weekly rebuilds."
 }


### PR DESCRIPTION
## 📋 PR Type

- [ ] 🐛 **Bug fix** (non-breaking change that fixes an issue)
- [ ] ✨ **New feature** (non-breaking change that adds functionality)
- [ ] 💥 **Breaking change** (fix or feature that would cause existing functionality to change)
- [ ] 📚 **Documentation** (changes to documentation only)
- [x] 🔧 **Configuration** (changes to templates, examples, or deployment configs)
- [ ] 🛡️ **Security** (security patch or hardening)
- [ ] 🏗️ **Build/CI** (changes to build process or CI/CD)

---

## 🔗 Related Issue

- Fixes #N/A

---

## 📝 Description

### What does this PR do?
Aligns `commitMessagePrefix` with the repo's gitmoji convention, adds `reviewers` to the `vulnerabilityAlerts` block, and adds a dedicated GitHub Actions package rule that automerges patch and digest updates.

### Why is this change needed?
The commit prefix didn't match the emoji-based convention used elsewhere in the repo, vulnerability alerts lacked reviewer coverage, and low-risk GitHub Actions bumps (patch/digest) were creating unnecessary manual review overhead.

---

## 🧪 Testing Performed

### Steps to Test

1. Validated `renovate.json` against the Renovate schema
2. Ran Renovate in dry-run mode to confirm the automerge rule only matches patch/digest GitHub Actions updates
3. Confirmed generated commit messages use the `⬆️ build(deps):` prefix

---

## 💥 Breaking Changes

- [x] **No breaking changes**

---

## ✅ Pre-Submission Checklist

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation as needed
- [ ] I have added an entry to CHANGELOG.md (if applicable)
- [x] I have removed sensitive information from logs/config examples